### PR TITLE
checkbox improvement + correction for when $fields is empty

### DIFF
--- a/wph-widget-class.php
+++ b/wph-widget-class.php
@@ -44,10 +44,7 @@ if (!class_exists('WPH_Widget'))
 			$args = wp_parse_args( $args, $defaults );
 			
 			// extract each arg to its own variable
-			extract( $args, EXTR_SKIP );
-			
-			// no fields? then theres not much to do
-			if (empty($fields)) return;
+			extract( $args, EXTR_SKIP );			
 						
 			// set the widget vars
 			$this->label   = $label;
@@ -345,7 +342,9 @@ if (!class_exists('WPH_Widget'))
 				case 'checkbox':
 
 					$out .= '<p>';
-
+					
+					$out .= $this->create_label($key['name'],$id);
+					
 					$out .= '<input type="checkbox" ';
 
 					if ( isset($key['class']))
@@ -357,8 +356,6 @@ if (!class_exists('WPH_Widget'))
 					$out .= ' checked="checked" ';			
 
 					$out .= ' /> ';
-
-					$out .= $this->create_label($key['name'],$id);
 
 				break;
 


### PR DESCRIPTION
Hey Matt,

Great work on the helper class. It's really useful.

I've made the following changes

A poor assumption was made that if $fields was empty then the widget
shouldn't be displayed. First of all, doing so caused a PHP error as the
widget was still being registered with WordPress. Secondly, it is
entirely conceivable (as was in my case) that a widget be generated
without any options at all, yet still use this class.  

The other change has to do with the checkbox field output, showing the label below the
checkbox did not look very good, especially with the ":", and thus I
moved it above the field.

Let me know what you think
